### PR TITLE
Integrate Pledge details page with the API

### DIFF
--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -2,6 +2,7 @@ import http from "../httpCommon";
 import { AidPackage } from "../../types/AidPackage";
 import { AidPackageUpdateComment } from "../../types/AidPackageUpdateComment";
 import { AidPackageItem } from "../../types/DonorAidPackageOrderItem";
+import { Pledge } from "../../types/Pledge";
 
 export class AidPackageService {
   static getAidPackages() {
@@ -18,7 +19,7 @@ export class AidPackageService {
 
   static getUpdateComments(packageID: number | string) {
     return http.get<AidPackageUpdateComment[]>(
-      `aidPackages/${packageID}/updatecomments`
+      `aidpackages/${packageID}/updatecomments`
     );
   }
 
@@ -27,7 +28,7 @@ export class AidPackageService {
     comment: AidPackageUpdateComment
   ) {
     return http.put<AidPackageUpdateComment>(
-      `aidPackages/${packageID}/updatecomments`,
+      `aidpackages/${packageID}/updatecomments`,
       comment
     );
   }
@@ -37,7 +38,7 @@ export class AidPackageService {
     packageUpdateID: number
   ) {
     return http.delete(
-      `aidPackages/${packageID}/updatecomment/${packageUpdateID}`
+      `aidpackages/${packageID}/updatecomment/${packageUpdateID}`
     );
   }
 
@@ -58,5 +59,9 @@ export class AidPackageService {
     return http.delete(
       `aidpackages/${packageID}/aidpackageitems/${packageItemID}`
     );
+  }
+
+  static getPledges(packageID: number | string) {
+    return http.get<Pledge[]>(`aidpackage/${packageID}/pledges`);
   }
 }

--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -18,7 +18,7 @@ export class AidPackageService {
 
   static getUpdateComments(packageID: number | string) {
     return http.get<AidPackageUpdateComment[]>(
-      `aidpackages/${packageID}/updatecomments`
+      `aidPackages/${packageID}/updatecomments`
     );
   }
 
@@ -27,17 +27,17 @@ export class AidPackageService {
     comment: AidPackageUpdateComment
   ) {
     return http.put<AidPackageUpdateComment>(
-      `aidpackages/${packageID}/updatecomments`,
+      `aidPackages/${packageID}/updatecomments`,
       comment
     );
   }
 
   static deleteUpdateComment(
     packageID: number | string,
-    packageUpdateCommentID: number
+    packageUpdateID: number
   ) {
     return http.delete(
-      `aidpackages/${packageID}/updatecomment/${packageUpdateCommentID}`
+      `aidPackages/${packageID}/updatecomment/${packageUpdateID}`
     );
   }
 

--- a/admin-portal/src/apis/services/PledgeService.ts
+++ b/admin-portal/src/apis/services/PledgeService.ts
@@ -1,8 +1,13 @@
 import http from "../httpCommon";
 import { PledgeActivity } from "../../types/PledgeActivity";
 import { AidPackageUpdateComment } from "../../types/AidPackageUpdateComment";
+import { Pledge } from "../../types/Pledge";
 
 export class PledgeService {
+  static getPledge(pledgeID: number | string) {
+    return http.get<Pledge>(`pledges/${pledgeID}`);
+  }
+
   static deletePledge(pledgeID: number | string) {
     return http.delete(`pledges/${pledgeID}`);
   }

--- a/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.css
+++ b/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.css
@@ -17,8 +17,7 @@
   font-weight: bold;
 }
 
-.aid-package-details .input-group textarea,
-input {
+.aid-package-details .input-group textarea, .aid-package-details .input-group input {
   font-family: Arial, Helvetica, sans-serif;
   font-size: 1rem;
   padding: 0.5rem;

--- a/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.css
+++ b/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.css
@@ -17,7 +17,8 @@
   font-weight: bold;
 }
 
-.aid-package-details .input-group textarea, .aid-package-details .input-group input {
+.aid-package-details .input-group textarea,
+.aid-package-details .input-group input {
   font-family: Arial, Helvetica, sans-serif;
   font-size: 1rem;
   padding: 0.5rem;

--- a/admin-portal/src/pages/editPledge/editPledge.tsx
+++ b/admin-portal/src/pages/editPledge/editPledge.tsx
@@ -12,22 +12,23 @@ import Modal from "../../components/modal/modal";
 import EditActivityPrompt from "./components/editActivityPrompt/editActivityPrompt";
 import "./editPledge.css";
 import { AidPackageService } from "../../apis/services/AidPackageService";
+import { PledgeService } from "../../apis/services/PledgeService";
 
 const demoDonor: Donor = {
   donorID: 0,
   email: "",
   orgLink: "",
   orgName: "Suwasetha Charity",
-  phone: 0,
+  phoneNumber: 0,
   quotationID: 0,
 };
 
-const demoPledge: Pledge = {
-  aidPackageID: 0,
-  amount: 1000,
-  donorID: 0,
-  status: Pledge.Status.Created,
-};
+// const demoPledge: Pledge = {
+//   packageID: 0,
+//   amount: 1000,
+//   donorID: 0,
+//   status: Pledge.Status.Created,
+// };
 
 const demoActivities: PledgeActivity[] = [
   {
@@ -48,7 +49,7 @@ const demoActivities: PledgeActivity[] = [
 export default function EditPledge() {
   const { packageId } = useParams<{ packageId: string }>();
   const [aidPackage, setAidPackage] = useState<AidPackage>();
-  const [pledge, setPledge] = useState<Pledge>(demoPledge);
+  const [pledge, setPledge] = useState<Pledge>();
   const [donor, setDonor] = useState<Donor>(demoDonor);
   const [activities, setActivities] =
     useState<PledgeActivity[]>(demoActivities);
@@ -58,11 +59,17 @@ export default function EditPledge() {
 
   useEffect(() => {
     fetchAidPackage();
+    fetchPledge();
   }, []);
 
   const fetchAidPackage = async () => {
     const { data } = await AidPackageService.getAidPackage(packageId!);
     setAidPackage(data);
+  };
+
+  const fetchPledge = async () => {
+    const { data } = await PledgeService.getPledge(packageId!);
+    setPledge(data);
   };
 
   const handleEditActivityClick = (activity: PledgeActivity) => {
@@ -93,15 +100,15 @@ export default function EditPledge() {
     );
     if (confirmed) {
       // Call the API
-      setPledge((prevPledge) => ({ ...prevPledge, status })); // Demo
+      setPledge((prevPledge) => ({ ...prevPledge!, status })); // Demo
     }
   };
 
   return (
     <Page selection={PageSelection.HOME}>
       <>
-        {!aidPackage && <p>Loading Aid Package...</p>}
-        {aidPackage && (
+        {(!aidPackage || !pledge) && <p>Loading Aid Package...</p>}
+        {aidPackage && pledge && (
           <div className="editPledge">
             <div>
               <Link to="/">Aid Packages</Link>&nbsp;&gt;&nbsp;
@@ -126,7 +133,7 @@ export default function EditPledge() {
             </Modal>
             <PledgeSummary
               donor={donor}
-              pledge={pledge}
+              pledge={pledge!}
               onStatusChange={handleStatusChange}
             />
             <PledgeActivities

--- a/admin-portal/src/pages/editPledge/editPledge.tsx
+++ b/admin-portal/src/pages/editPledge/editPledge.tsx
@@ -23,13 +23,6 @@ const demoDonor: Donor = {
   quotationID: 0,
 };
 
-// const demoPledge: Pledge = {
-//   packageID: 0,
-//   amount: 1000,
-//   donorID: 0,
-//   status: Pledge.Status.Created,
-// };
-
 const demoActivities: PledgeActivity[] = [
   {
     pledgeID: 0,

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -26,7 +26,7 @@ export default function OrderItemsTable({
         {items.map((item) => (
           <tr key={item.packageItemID}>
             <td>
-              {/*{item.quotation.brandName} TODO: Uncomment when the field is there on the response */}
+              {item.quotation.brandName}
             </td>
             <td>{item.quantity}</td>
             <td className="actions">

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -25,9 +25,7 @@ export default function OrderItemsTable({
       <tbody>
         {items.map((item) => (
           <tr key={item.packageItemID}>
-            <td>
-              {item.quotation.brandName}
-            </td>
+            <td>{item.quotation.brandName}</td>
             <td>{item.quantity}</td>
             <td className="actions">
               <button onClick={() => onEditItemButtonClick(item)}>Edit</button>

--- a/admin-portal/src/pages/packageDetails/components/packageStatus/packageStatus.tsx
+++ b/admin-portal/src/pages/packageDetails/components/packageStatus/packageStatus.tsx
@@ -2,19 +2,9 @@ import React from "react";
 import "./packageStatus.css";
 import { AidPackage } from "../../../../types/AidPackage";
 
-const statusToLabel: { [key in AidPackage.Status]: string } = {
-  [AidPackage.Status.Draft]: "Draft",
-  [AidPackage.Status.Published]: "Published",
-  [AidPackage.Status.AwaitingPayment]: "Awaiting Payment",
-  [AidPackage.Status.Ordered]: "Ordered",
-  [AidPackage.Status.Shipped]: "Shipped",
-  [AidPackage.Status.ReceivedAtMOH]: "Received at MOH",
-  [AidPackage.Status.Delivered]: "Delivered",
-};
-
 interface PackageStatusProps {
   currentStatus: AidPackage.Status;
-  onStatusChange: (statusToBeChanged: AidPackage.Status, label: string) => void;
+  onStatusChange: (statusToBeChanged: AidPackage.Status) => void;
 }
 
 export default function PackageStatus({
@@ -26,18 +16,18 @@ export default function PackageStatus({
       <p className="heading">Status</p>
       <div>
         <div>
-          {Object.entries(statusToLabel).map(([status, label], index) => (
-            <span className="statusLabel" key={status}>
+          {Object.entries(AidPackage.Status).map(([key, status], index) => (
+            <span className="statusLabel" key={key}>
               <input
                 type="checkbox"
-                id={status}
+                id={key}
                 checked={status === currentStatus}
                 onChange={(event) => {
-                  onStatusChange(status as AidPackage.Status, label);
+                  onStatusChange(status as AidPackage.Status);
                 }}
               />
-              <label htmlFor={status}>{label}</label>
-              {index + 1 < Object.entries(statusToLabel).length && (
+              <label htmlFor={key}>{status}</label>
+              {index + 1 < Object.entries(AidPackage.Status).length && (
                 <span>&nbsp;&gt;&nbsp;</span>
               )}
             </span>

--- a/admin-portal/src/pages/packageDetails/components/updateComments/updateComments.tsx
+++ b/admin-portal/src/pages/packageDetails/components/updateComments/updateComments.tsx
@@ -45,7 +45,7 @@ export default function UpdateComments({
       </div>
       <div className="comment">
         {posts.map((post) => (
-          <div key={post.packageUpdateId} className="post">
+          <div key={post.packageUpdateID} className="post">
             <p className="date">{post.dateTime}</p>
             <div className="content">
               <span className="text">{post.updateComment}</span>

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -61,9 +61,7 @@ export function PackageDetails() {
     setIsEditOrderItemModalVisible(false);
   };
 
-  const handleStatusChange = async (
-    statusToBeChanged: AidPackage.Status,
-  ) => {
+  const handleStatusChange = async (statusToBeChanged: AidPackage.Status) => {
     if (statusToBeChanged === aidPackage?.status) {
       return;
     }
@@ -94,7 +92,10 @@ export function PackageDetails() {
       `Are you sure you want to delete item ${item.quotation.brandName}?`
     );
     if (confirmed) {
-      await AidPackageService.deleteAidPackageItem(packageId!, item.packageItemID);
+      await AidPackageService.deleteAidPackageItem(
+        packageId!,
+        item.packageItemID
+      );
       await fetchAidPackage();
     }
   };
@@ -106,7 +107,7 @@ export function PackageDetails() {
       "Are you sure you want to delete this post?"
     );
     if (confirmed) {
-      debugger
+      debugger;
       await AidPackageService.deleteUpdateComment(
         packageId!,
         updateComment.packageUpdateID

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -63,13 +63,12 @@ export function PackageDetails() {
 
   const handleStatusChange = async (
     statusToBeChanged: AidPackage.Status,
-    label: string
   ) => {
     if (statusToBeChanged === aidPackage?.status) {
       return;
     }
     const confirmed = window.confirm(
-      `Are you sure you want to change the status to ${label}?`
+      `Are you sure you want to change the status to ${statusToBeChanged}?`
     );
     if (confirmed) {
       const { data } = await AidPackageService.updateAidPackage({
@@ -82,20 +81,21 @@ export function PackageDetails() {
 
   const handleNewComment = async (comment: string) => {
     await AidPackageService.upsertUpdateComment(packageId!, {
-      packageUpdateId: 0,
+      packageUpdateID: 0,
       packageID: parseInt(packageId!),
       updateComment: comment,
       dateTime: "",
     });
-    await fetchAidPackage();
+    await fetchUpdateComments();
   };
 
-  const handlePackageItemDelete = (item: AidPackageItem) => {
+  const handlePackageItemDelete = async (item: AidPackageItem) => {
     const confirmed = window.confirm(
       `Are you sure you want to delete item ${item.quotation.brandName}?`
     );
     if (confirmed) {
-      // await AidPackageService.deleteUpdateComment()
+      await AidPackageService.deleteAidPackageItem(packageId!, item.packageItemID);
+      await fetchAidPackage();
     }
   };
 
@@ -106,10 +106,12 @@ export function PackageDetails() {
       "Are you sure you want to delete this post?"
     );
     if (confirmed) {
+      debugger
       await AidPackageService.deleteUpdateComment(
         packageId!,
-        updateComment.packageUpdateId
+        updateComment.packageUpdateID
       );
+      fetchUpdateComments();
     }
   };
 

--- a/admin-portal/src/pages/pledgeStatus/donorTable/donorTable.tsx
+++ b/admin-portal/src/pages/pledgeStatus/donorTable/donorTable.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { DonorAidPackagePledge } from "../../../types/DonarAidPackagePledge";
+import { Pledge } from "../../../types/Pledge";
 
 interface DonorTableProps {
-  pledges: DonorAidPackagePledge[];
-  onPledgeDelete: (pledge: DonorAidPackagePledge) => void;
-  onPledgeEdit: (pledge: DonorAidPackagePledge) => void;
+  pledges: Pledge[];
+  onPledgeDelete: (pledge: Pledge) => void;
+  onPledgeEdit: (pledge: Pledge) => void;
 }
 
 export default function DonorTable({
@@ -25,8 +25,8 @@ export default function DonorTable({
         </thead>
         <tbody>
           {pledges.map((pledge) => (
-            <tr key={pledge.id}>
-              <td>{pledge.name}</td>
+            <tr key={pledge.pledgeID}>
+              <td>{pledge.donor.orgName}</td>
               <td>{pledge.amount}</td>
               <td>{pledge.status}</td>
               <td>

--- a/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
+++ b/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
@@ -6,24 +6,8 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import DonorTable from "./donorTable/donorTable";
 import "./pledgeStatus.css";
 import ContributionsChart from "../../components/contributionsChart/contributionsChart";
-import { DonorAidPackagePledge } from "../../types/DonarAidPackagePledge";
 import { AidPackageService } from "../../apis/services/AidPackageService";
 import { Pledge } from "../../types/Pledge";
-
-// const demoPledges: DonorAidPackagePledge[] = [
-//   {
-//     id: 1,
-//     name: "Suwasetha Charity",
-//     amount: 1000,
-//     status: "Created",
-//   },
-//   {
-//     id: 2,
-//     name: "Some Charity",
-//     amount: 875,
-//     status: "Created",
-//   },
-// ];
 
 export default function PledgeStatus() {
   const { packageId } = useParams<{ packageId: string }>();

--- a/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
+++ b/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
@@ -8,30 +8,32 @@ import "./pledgeStatus.css";
 import ContributionsChart from "../../components/contributionsChart/contributionsChart";
 import { DonorAidPackagePledge } from "../../types/DonarAidPackagePledge";
 import { AidPackageService } from "../../apis/services/AidPackageService";
+import { Pledge } from "../../types/Pledge";
 
-const demoPledges: DonorAidPackagePledge[] = [
-  {
-    id: 1,
-    name: "Suwasetha Charity",
-    amount: 1000,
-    status: "Created",
-  },
-  {
-    id: 2,
-    name: "Some Charity",
-    amount: 875,
-    status: "Created",
-  },
-];
+// const demoPledges: DonorAidPackagePledge[] = [
+//   {
+//     id: 1,
+//     name: "Suwasetha Charity",
+//     amount: 1000,
+//     status: "Created",
+//   },
+//   {
+//     id: 2,
+//     name: "Some Charity",
+//     amount: 875,
+//     status: "Created",
+//   },
+// ];
 
 export default function PledgeStatus() {
   const { packageId } = useParams<{ packageId: string }>();
   const [aidPackage, setAidPackage] = useState<AidPackage>();
-  const [pledges, setPledges] = useState<DonorAidPackagePledge[]>(demoPledges);
+  const [pledges, setPledges] = useState<Pledge[]>([]);
   const navigate = useNavigate();
 
   useEffect(() => {
     fetchAidPackage();
+    fetchPledges();
   }, []);
 
   const fetchAidPackage = async () => {
@@ -39,13 +41,18 @@ export default function PledgeStatus() {
     setAidPackage(data);
   };
 
-  const handlePledgeEdit = (pledge: DonorAidPackagePledge) => {
-    navigate(`pledges/${pledge.id}`);
+  const fetchPledges = async () => {
+    const { data } = await AidPackageService.getPledges(packageId!);
+    setPledges(data);
   };
 
-  const handlePledgeDelete = (pledge: DonorAidPackagePledge) => {
+  const handlePledgeEdit = (pledge: Pledge) => {
+    navigate(`pledges/${pledge.pledgeID}`);
+  };
+
+  const handlePledgeDelete = (pledge: Pledge) => {
     const confirmed = window.confirm(
-      `Are you sure you want to delete the pledge of ${pledge.name}?`
+      `Are you sure you want to delete the pledge of ${pledge.donor.orgName}?`
     );
     if (confirmed) {
       // Call the api

--- a/admin-portal/src/types/AidPackage.ts
+++ b/admin-portal/src/types/AidPackage.ts
@@ -12,10 +12,10 @@ export namespace AidPackage {
   export enum Status {
     Draft = "Draft",
     Published = "Published",
-    AwaitingPayment = "AwaitingPayment",
+    AwaitingPayment = "Awaiting Payment",
     Ordered = "Ordered",
     Shipped = "Shipped",
-    ReceivedAtMOH = "ReceivedAtMOH",
+    ReceivedAtMOH = "Received At MOH",
     Delivered = "Delivered",
   }
 }

--- a/admin-portal/src/types/AidPackageUpdateComment.ts
+++ b/admin-portal/src/types/AidPackageUpdateComment.ts
@@ -1,6 +1,6 @@
 export interface AidPackageUpdateComment {
   packageID: number;
-  packageUpdateId: number;
+  packageUpdateID: number;
   updateComment: string;
   dateTime: string;
 }

--- a/admin-portal/src/types/Donor.ts
+++ b/admin-portal/src/types/Donor.ts
@@ -3,6 +3,6 @@ export interface Donor {
   orgName: string;
   orgLink: string;
   email: string;
-  phone: number;
+  phoneNumber: number;
   quotationID: number;
 }

--- a/admin-portal/src/types/DonorAidPackageOrderItem.ts
+++ b/admin-portal/src/types/DonorAidPackageOrderItem.ts
@@ -1,8 +1,6 @@
 import { Quotation } from "./Quotation";
 
-export interface PartialAidPackageItem {
-
-}
+export interface PartialAidPackageItem {}
 
 export interface AidPackageItem {
   packageItemID: number;

--- a/admin-portal/src/types/DonorAidPackageOrderItem.ts
+++ b/admin-portal/src/types/DonorAidPackageOrderItem.ts
@@ -1,5 +1,9 @@
 import { Quotation } from "./Quotation";
 
+export interface PartialAidPackageItem {
+
+}
+
 export interface AidPackageItem {
   packageItemID: number;
   packageID: number;

--- a/admin-portal/src/types/Pledge.ts
+++ b/admin-portal/src/types/Pledge.ts
@@ -1,8 +1,12 @@
+import { Donor } from "./Donor";
+
 export interface Pledge {
-  aidPackageID: number;
+  pledgeID: number;
+  packageID: number;
   donorID: number;
   amount: number;
   status: Pledge.Status;
+  donor: Donor;
 }
 
 export namespace Pledge {


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to integrate the pledge details page with the backend and to fix the broken aid package details page.

## Goals 
- To display a pledge summary of an Aid package

## Approach
- Change resource URLs of APIs and types according to the latest version of the Admin API
- Wire the Pledge details page