### PR TITLE
Clear the file upload input after success call

### DIFF
--- a/admin-portal/src/pages/needUpload/needUpload.css
+++ b/admin-portal/src/pages/needUpload/needUpload.css
@@ -70,4 +70,5 @@ select:focus {
   margin-top: 40px;
   font-size: 14px;
   margin-left: 10px;
+  white-space: pre-wrap;
 }

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -10,7 +10,6 @@ export function NeedUpload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
   const [responseData, setResponseData] = useState("");
-  const [g, setG] = useState("");
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setResponseData("");

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -9,10 +9,10 @@ import axios, { AxiosError } from "axios";
 export function NeedUpload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
-  const [errorList, setErrorList] = useState<string[]>([]);
+  const [responseData, setResponseData] = useState<string[]>([]);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
-    setErrorList([]);
+    setResponseData([]);
     if (event.target.files) {
       setFile(event.target.files[0]);
     }
@@ -27,7 +27,7 @@ export function NeedUpload() {
       formData.append("file", file);
       try {
         const response = await AidPackageService.postNeeds(formData);
-        toast.success(response.data, {
+        toast.success("File uploaded successfully!", {
           position: "top-right",
           autoClose: 5000,
           hideProgressBar: true,
@@ -36,6 +36,7 @@ export function NeedUpload() {
           draggable: true,
         });
         setFileName("");
+        setResponseData(response.data.split("|"));
       } catch (e) {
         if (axios.isAxiosError(e)) {
           const error = e as AxiosError<string>;
@@ -49,7 +50,7 @@ export function NeedUpload() {
           });
           if (error.response) {
             const data = error.response.data.split(/\r?\n/);
-            setErrorList(data);
+            setResponseData(data);
           }
         }
       }
@@ -85,8 +86,8 @@ export function NeedUpload() {
           </form>
         </div>
         <div className="error-list-div">
-          {errorList.length > 0 &&
-            errorList.map((error: string) => <p key={error}>{error}</p>)}
+          {responseData.length > 0 &&
+            responseData.map((error: string) => <p key={error}>{error}</p>)}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -87,7 +87,9 @@ export function NeedUpload() {
         </div>
         <div className="error-list-div">
           {responseData.length > 0 &&
-            responseData.map((error: string) => <p key={error}>{error}</p>)}
+            responseData.map((error: string, index: number) => (
+              <p key={index}>{error}</p>
+            ))}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -9,10 +9,11 @@ import axios, { AxiosError } from "axios";
 export function NeedUpload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
-  const [responseData, setResponseData] = useState<string[]>([]);
+  const [responseData, setResponseData] = useState("");
+  const [g, setG] = useState("");
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
-    setResponseData([]);
+    setResponseData("");
     if (event.target.files) {
       setFile(event.target.files[0]);
     }
@@ -36,7 +37,7 @@ export function NeedUpload() {
           draggable: true,
         });
         setFileName("");
-        setResponseData(response.data.split("|"));
+        setResponseData(response.data);
       } catch (e) {
         if (axios.isAxiosError(e)) {
           const error = e as AxiosError<string>;
@@ -49,8 +50,7 @@ export function NeedUpload() {
             draggable: true,
           });
           if (error.response) {
-            const data = error.response.data.split(/\r?\n/);
-            setResponseData(data);
+            setResponseData(error.response.data);
           }
         }
       }
@@ -85,12 +85,7 @@ export function NeedUpload() {
             <button type="submit">Upload</button>
           </form>
         </div>
-        <div className="error-list-div">
-          {responseData.length > 0 &&
-            responseData.map((error: string, index: number) => (
-              <p key={index}>{error}</p>
-            ))}
-        </div>
+        <div className="error-list-div">{responseData}</div>
       </div>
     </Page>
   );

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -1,59 +1,55 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router";
 import { PageSelection } from "../../types/pages";
 import { Page } from "layout/page";
 import "./needUpload.css";
 import { AidPackageService } from "apis/services/AidPackageService";
-import { ToastContainer, toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import { toast } from "react-toastify";
 
 export function NeedUpload() {
   const [file, setFile] = useState(null);
+  const [fileName, setFileName] = useState("");
   const [errorList, setErrorList] = useState([]);
-  const navigate = useNavigate();
 
   function handleChange(event: any) {
     setErrorList([]);
     setFile(event.target.files[0]);
+    setFileName(event.target.value);
   }
 
   const handleSubmit = async (event: any) => {
     event.preventDefault();
-
     const formData = new FormData();
 
     if (file != undefined) {
       formData.append("file", file);
-      AidPackageService.postNeeds(formData)
-        .then((response) => {
-          toast.success(response.data, {
-            position: "top-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
-
-          navigate("/");
-        })
-        .catch((error) => {
-          toast.error("File upload unsuccessful", {
-            position: "top-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
-
-          const data = error.response.data
-            .split(/\r?\n/)
-            .filter((element: any) => element);
-          setErrorList(data);
+      try {
+        const response = await AidPackageService.postNeeds(formData);
+        toast.success(response.data, {
+          position: "top-right",
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
         });
+        setFileName("");
+      } catch (e: any) {
+        toast.error("File upload unsuccessful", {
+          position: "top-right",
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+        });
+
+        const data = e.response.data
+          .split(/\r?\n/)
+          .filter((element: any) => element);
+        setErrorList(data);
+      }
     } else {
       toast.warn("Please select a file to upload", {
         position: "top-right",
@@ -77,13 +73,18 @@ export function NeedUpload() {
         <div className="uploadNeedsContainer">
           <form onSubmit={handleSubmit}>
             <p>Select the needs csv file that you want to upload.</p>
-            <input type="file" accept=".csv" onChange={handleChange} />
+            <input
+              type="file"
+              accept=".csv"
+              onChange={handleChange}
+              value={fileName}
+            />
             <button type="submit">Upload</button>
           </form>
         </div>
         <div className="error-list-div">
           {errorList.length > 0 &&
-            errorList.map((error: any) => <p>{error}</p>)}
+            errorList.map((error: string) => <p>{error}</p>)}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.css
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.css
@@ -65,4 +65,5 @@
   margin-top: 40px;
   font-size: 14px;
   margin-left: 10px;
+  white-space: pre-wrap;
 }

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
@@ -9,10 +9,10 @@ import axios, { AxiosError } from "axios";
 export function SupplierQuotationUpload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
-  const [errorList, setErrorList] = useState<string[]>([]);
+  const [responseData, setResponseData] = useState<string[]>([]);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
-    setErrorList([]);
+    setResponseData([]);
     if (event.target.files) {
       setFile(event.target.files[0]);
     }
@@ -27,7 +27,7 @@ export function SupplierQuotationUpload() {
       formData.append("file", file);
       try {
         const response = await SupplierService.postQuotation(formData);
-        toast.success(response.data, {
+        toast.success("File uploaded successfully!", {
           position: "top-right",
           autoClose: 5000,
           hideProgressBar: true,
@@ -36,6 +36,7 @@ export function SupplierQuotationUpload() {
           draggable: true,
         });
         setFileName("");
+        setResponseData(response.data.split("|"));
       } catch (e) {
         if (axios.isAxiosError(e)) {
           const error = e as AxiosError<string>;
@@ -49,7 +50,7 @@ export function SupplierQuotationUpload() {
           });
           if (error.response) {
             const data = error.response.data.split(/\r?\n/);
-            setErrorList(data);
+            setResponseData(data);
           }
         }
       }
@@ -88,8 +89,8 @@ export function SupplierQuotationUpload() {
           </form>
         </div>
         <div className="error-list-div">
-          {errorList.length > 0 &&
-            errorList.map((error: string) => <p key={error}>{error}</p>)}
+          {responseData.length > 0 &&
+            responseData.map((error: string) => <p key={error}>{error}</p>)}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
@@ -9,10 +9,10 @@ import axios, { AxiosError } from "axios";
 export function SupplierQuotationUpload() {
   const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
-  const [responseData, setResponseData] = useState<string[]>([]);
+  const [responseData, setResponseData] = useState("");
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
-    setResponseData([]);
+    setResponseData("");
     if (event.target.files) {
       setFile(event.target.files[0]);
     }
@@ -36,7 +36,7 @@ export function SupplierQuotationUpload() {
           draggable: true,
         });
         setFileName("");
-        setResponseData(response.data.split("|"));
+        setResponseData(response.data);
       } catch (e) {
         if (axios.isAxiosError(e)) {
           const error = e as AxiosError<string>;
@@ -49,8 +49,7 @@ export function SupplierQuotationUpload() {
             draggable: true,
           });
           if (error.response) {
-            const data = error.response.data.split(/\r?\n/);
-            setResponseData(data);
+            setResponseData(error.response.data);
           }
         }
       }
@@ -88,12 +87,7 @@ export function SupplierQuotationUpload() {
             <button type="submit">Upload</button>
           </form>
         </div>
-        <div className="error-list-div">
-          {responseData.length > 0 &&
-            responseData.map((error: string, index: number) => (
-              <p key={index}>{error}</p>
-            ))}
-        </div>
+        <div className="error-list-div">{responseData}</div>
       </div>
     </Page>
   );

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
@@ -1,26 +1,29 @@
-import React, { useState } from "react";
+import React, { useState, ChangeEvent, FormEvent } from "react";
 import { PageSelection } from "../../types/pages";
 import { Page } from "layout/page";
 import "./supplierQuotationUpload.css";
 import { SupplierService } from "apis/services/SupplierService";
 import { toast } from "react-toastify";
+import axios, { AxiosError } from "axios";
 
 export function SupplierQuotationUpload() {
-  const [file, setFile] = useState(null);
+  const [file, setFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState("");
-  const [errorList, setErrorList] = useState([]);
+  const [errorList, setErrorList] = useState<string[]>([]);
 
-  function handleChange(event: any) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
     setErrorList([]);
-    setFile(event.target.files[0]);
+    if (event.target.files) {
+      setFile(event.target.files[0]);
+    }
     setFileName(event.target.value);
   }
 
-  const handleSubmit = async (event: any) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData();
 
-    if (file != undefined) {
+    if (file) {
       formData.append("file", file);
       try {
         const response = await SupplierService.postQuotation(formData);
@@ -31,24 +34,24 @@ export function SupplierQuotationUpload() {
           closeOnClick: true,
           pauseOnHover: true,
           draggable: true,
-          progress: undefined,
         });
         setFileName("");
-      } catch (e: any) {
-        toast.error("File upload unsuccessful", {
-          position: "top-right",
-          autoClose: 5000,
-          hideProgressBar: true,
-          closeOnClick: true,
-          pauseOnHover: true,
-          draggable: true,
-          progress: undefined,
-        });
-
-        const data = e.response.data
-          .split(/\r?\n/)
-          .filter((element: any) => element);
-        setErrorList(data);
+      } catch (e) {
+        if (axios.isAxiosError(e)) {
+          const error = e as AxiosError<string>;
+          toast.error("File upload unsuccessful", {
+            position: "top-right",
+            autoClose: 5000,
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+          });
+          if (error.response) {
+            const data = error.response.data.split(/\r?\n/);
+            setErrorList(data);
+          }
+        }
       }
     } else {
       toast.warn("Please select a file to upload", {
@@ -58,7 +61,6 @@ export function SupplierQuotationUpload() {
         closeOnClick: true,
         pauseOnHover: true,
         draggable: true,
-        progress: undefined,
       });
     }
   };
@@ -87,7 +89,7 @@ export function SupplierQuotationUpload() {
         </div>
         <div className="error-list-div">
           {errorList.length > 0 &&
-            errorList.map((error: string) => <p>{error}</p>)}
+            errorList.map((error: string) => <p key={error}>{error}</p>)}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
@@ -1,20 +1,19 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router";
 import { PageSelection } from "../../types/pages";
 import { Page } from "layout/page";
 import "./supplierQuotationUpload.css";
 import { SupplierService } from "apis/services/SupplierService";
-import { ToastContainer, toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import { toast } from "react-toastify";
 
 export function SupplierQuotationUpload() {
   const [file, setFile] = useState(null);
+  const [fileName, setFileName] = useState("");
   const [errorList, setErrorList] = useState([]);
-  const navigate = useNavigate();
 
   function handleChange(event: any) {
     setErrorList([]);
     setFile(event.target.files[0]);
+    setFileName(event.target.value);
   }
 
   const handleSubmit = async (event: any) => {
@@ -23,36 +22,34 @@ export function SupplierQuotationUpload() {
 
     if (file != undefined) {
       formData.append("file", file);
-      SupplierService.postQuotation(formData)
-        .then((response) => {
-          toast.success(response.data, {
-            position: "top-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
-
-          navigate("/");
-        })
-        .catch((error) => {
-          toast.error("File upload unsuccessful", {
-            position: "top-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
-
-          const data = error.response.data
-            .split(/\r?\n/)
-            .filter((element: any) => element);
-          setErrorList(data);
+      try {
+        const response = await SupplierService.postQuotation(formData);
+        toast.success(response.data, {
+          position: "top-right",
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
         });
+        setFileName("");
+      } catch (e: any) {
+        toast.error("File upload unsuccessful", {
+          position: "top-right",
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+        });
+
+        const data = e.response.data
+          .split(/\r?\n/)
+          .filter((element: any) => element);
+        setErrorList(data);
+      }
     } else {
       toast.warn("Please select a file to upload", {
         position: "top-right",
@@ -79,13 +76,18 @@ export function SupplierQuotationUpload() {
         <div className="uploadSupplierQuotationContainer">
           <form onSubmit={handleSubmit}>
             <p>Select the needs csv file that you want to upload.</p>
-            <input type="file" accept=".csv" onChange={handleChange} />
+            <input
+              type="file"
+              accept=".csv"
+              onChange={handleChange}
+              value={fileName}
+            />
             <button type="submit">Upload</button>
           </form>
         </div>
         <div className="error-list-div">
           {errorList.length > 0 &&
-            errorList.map((error: any) => <p>{error}</p>)}
+            errorList.map((error: string) => <p>{error}</p>)}
         </div>
       </div>
     </Page>

--- a/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
+++ b/admin-portal/src/pages/supplierQuotationUpload/supplierQuotationUpload.tsx
@@ -90,7 +90,9 @@ export function SupplierQuotationUpload() {
         </div>
         <div className="error-list-div">
           {responseData.length > 0 &&
-            responseData.map((error: string) => <p key={error}>{error}</p>)}
+            responseData.map((error: string, index: number) => (
+              <p key={index}>{error}</p>
+            ))}
         </div>
       </div>
     </Page>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to make changes requested under pr #63

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
* To clear out the input field after successfully uploading a file. 
* To make changes to the code to maintain the consistency with the rest of the codebase. 

## Comments
* I have left the `react-toastify` library for now.
