### PR TITLE
Add decimals and thousand separators to aid package amounts

### DIFF
--- a/admin-portal/src/pages/editPledge/components/pledgeSummary/pledgeSummary.tsx
+++ b/admin-portal/src/pages/editPledge/components/pledgeSummary/pledgeSummary.tsx
@@ -26,7 +26,13 @@ export default function PledgeSummary({
       <div className="heading">Donor:</div>
       <div>{donor.orgName}</div>
       <div className="heading">Amount:</div>
-      <div>$ {pledge.amount}</div>
+      <div>
+        ${" "}
+        {pledge.amount.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}
+      </div>
       <div className="heading">Status:</div>
       <div>
         <select onChange={handleStatusChange} value={pledge.status}>

--- a/admin-portal/src/pages/editPledge/components/pledgeSummary/pledgeSummary.tsx
+++ b/admin-portal/src/pages/editPledge/components/pledgeSummary/pledgeSummary.tsx
@@ -27,7 +27,7 @@ export default function PledgeSummary({
       <div>{donor.orgName}</div>
       <div className="heading">Amount:</div>
       <div>
-        ${" "}
+        $
         {pledge.amount.toLocaleString(undefined, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -163,8 +163,20 @@ export function PackageDetails() {
                   receivedAmount={aidPackage.receivedAmount}
                 />
               </div>
-              <p>Goal: ${aidPackage.goalAmount}</p>
-              <p>Received: ${aidPackage.receivedAmount}</p>
+              <p>
+                Goal: $
+                {aidPackage.goalAmount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
+              <p>
+                Received: $
+                {aidPackage.receivedAmount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
               <Link to={`/packages/${packageId}/pledge-status`}>
                 See pledge status
               </Link>

--- a/admin-portal/src/pages/pledgeStatus/donorTable/donorTable.tsx
+++ b/admin-portal/src/pages/pledgeStatus/donorTable/donorTable.tsx
@@ -27,7 +27,13 @@ export default function DonorTable({
           {pledges.map((pledge) => (
             <tr key={pledge.pledgeID}>
               <td>{pledge.donor.orgName}</td>
-              <td>{pledge.amount}</td>
+              <td>
+                $
+                {pledge.amount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </td>
               <td>{pledge.status}</td>
               <td>
                 <button onClick={() => onPledgeEdit(pledge)}>Edit</button>

--- a/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
+++ b/admin-portal/src/pages/pledgeStatus/pledgeStatus.tsx
@@ -64,8 +64,20 @@ export default function PledgeStatus() {
               />
             </div>
             <div>
-              <p>Goal: ${aidPackage.goalAmount}</p>
-              <p>Received: ${aidPackage.receivedAmount}</p>
+              <p>
+                Goal: $
+                {aidPackage.goalAmount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
+              <p>
+                Received: $
+                {aidPackage.receivedAmount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
               <p>Status: {aidPackage.status}</p>
             </div>
           </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #131

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Add decimal points and thousand separators to amounts on aid packages and pledges. 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![image](https://user-images.githubusercontent.com/72991092/178470879-9a58b7df-3fb9-43da-8b9a-c89f5a39afeb.png)


