### PR TITLE
Fix uploading issue temporarily

### DIFF
--- a/admin-portal/src/apis/httpCommon.ts
+++ b/admin-portal/src/apis/httpCommon.ts
@@ -1,7 +1,13 @@
 import { AsgardeoSPAClient, HttpRequestConfig } from "@asgardeo/auth-spa";
-import { AxiosResponse } from "axios";
+import axios, { AxiosResponse } from "axios";
 
 const auth = AsgardeoSPAClient.getInstance();
+
+export const temporaryClient = axios.create({
+  baseURL:
+    "https://9d2b57ae-4349-44f2-971c-106ae09d244d-prod.e1-us-east-azure.choreoapis.dev/qmov/admin-api/1.0.0",
+});
+
 
 export default class Http {
   httpRequest: (config: HttpRequestConfig) => Promise<any>;

--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -1,4 +1,4 @@
-import Http from "../httpCommon";
+import Http, {temporaryClient} from "../httpCommon";
 import { AidPackage } from "../../types/AidPackage";
 import { AidPackageUpdateComment } from "../../types/AidPackageUpdateComment";
 import { AidPackageItem } from "../../types/DonorAidPackageOrderItem";
@@ -73,7 +73,7 @@ export class AidPackageService {
   }
 
   static postNeeds(formData: any) {
-    return AidPackageService.http.post<any, string>(
+    return temporaryClient.post<string>(
       `requirements/medicalneeds`,
       formData
     );

--- a/admin-portal/src/apis/services/SupplierService.ts
+++ b/admin-portal/src/apis/services/SupplierService.ts
@@ -1,11 +1,10 @@
-import { Quotation } from "types/Quotation";
-import Http from "../httpCommon";
+import Http, {temporaryClient} from "../httpCommon";
 
 export class SupplierService {
   static http: Http;
 
   static postQuotation(quotation: any) {
-    return SupplierService.http.post<Quotation, string>(
+    return temporaryClient.post<string>(
       `quotations`,
       quotation
     );

--- a/admin-portal/src/config.json
+++ b/admin-portal/src/config.json
@@ -1,7 +1,7 @@
 {
   "clientID": "W_ZaTLGR20OKy0HTYPqSAJvuS5Ia",
   "baseUrl": "https://api.asgardeo.io/t/elixir",
-  "signInRedirectURL": "https://admin-portal-rouge.vercel.app",
+  "signInRedirectURL": "http://localhost:3000",
   "signOutRedirectURL": "https://admin-portal-rouge.vercel.app",
   "scope": ["openid", "email", "profile"],
   "stsConfig": {

--- a/admin-portal/src/config.json
+++ b/admin-portal/src/config.json
@@ -1,7 +1,7 @@
 {
   "clientID": "W_ZaTLGR20OKy0HTYPqSAJvuS5Ia",
   "baseUrl": "https://api.asgardeo.io/t/elixir",
-  "signInRedirectURL": "http://localhost:3000",
+  "signInRedirectURL": "https://admin-portal-rouge.vercel.app",
   "signOutRedirectURL": "https://admin-portal-rouge.vercel.app",
   "scope": ["openid", "email", "profile"],
   "stsConfig": {

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -27,7 +27,7 @@ export function NeedUpload() {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData();
-
+debugger
     if (file) {
       formData.append("file", file);
       try {

--- a/admin-portal/src/pages/needUpload/needUpload.tsx
+++ b/admin-portal/src/pages/needUpload/needUpload.tsx
@@ -27,7 +27,6 @@ export function NeedUpload() {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData();
-debugger
     if (file) {
       formData.append("file", file);
       try {


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #159 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- To upload needs and quotations


## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Create a temporary axios instance

Observations: 
It throws: "Failed to execute 'postMessage' on 'Worker': FormData object could not be cloned." when trying to send the request. 

It also occurs when you provide both request and response datatypes through generics (on form data): ex: `axios.post<requestType, responseType >`  but works fine when providing only the response type.