### PR TITLE
Prevent rendering the application until signing in

### DIFF
--- a/admin-portal/src/App.tsx
+++ b/admin-portal/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import { NavBar } from "./components";
 import { Home } from "./pages/home/home";
@@ -21,6 +21,7 @@ import { SupplierService } from "apis/services/SupplierService";
 
 function App() {
   const { httpRequest, signIn, trySignInSilently } = useAuthContext();
+  const [isSigningIn, setIsSigningIn] = useState(true);
 
   useEffect(() => {
     trySignInSilently()
@@ -31,6 +32,9 @@ function App() {
       })
       .catch(() => {
         signIn();
+      })
+      .finally(() => {
+        setIsSigningIn(false);
       });
     const http: Http = new Http(
       httpRequest,
@@ -42,6 +46,9 @@ function App() {
     SupplierService.http = http;
   }, []);
 
+  if (isSigningIn) {
+    return <p>Loading...</p>;
+  }
   return (
     <div className="App">
       <header className="App-header">

--- a/admin-portal/src/layout/page.tsx
+++ b/admin-portal/src/layout/page.tsx
@@ -26,7 +26,7 @@ export function Page(props: PageProps) {
                       className="menu__link"
                       activeClassName="menu__link menu__link--active"
                     >
-                      Home
+                      Aid Packages
                     </NavLink>
                   </div>
                 </li>
@@ -38,7 +38,7 @@ export function Page(props: PageProps) {
                       className="menu__link"
                       activeClassName="menu__link menu__link--active"
                     >
-                      Aid Packages
+                      Create Aid Package
                     </NavLink>
                   </div>
                 </li>

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { PageSelection } from "../../types/pages";
 import "./packageDetails.css";
-import { Page } from "../../layout/page";
 import OrderItemsTable from "./components/orderItemsTable/orderItemsTable";
 import { AidPackage } from "../../types/AidPackage";
 import UpdateComments from "./components/updateComments/updateComments";


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #173 fix #172

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Render the application only after the silent sign in completes
- Change navbar titles
