### PR TITLE
Make item quantities editable only on draft status

### DIFF
--- a/admin-portal/src/pages/packageDetails/components/editOrderItemPrompt/editOrderItemPrompts.tsx
+++ b/admin-portal/src/pages/packageDetails/components/editOrderItemPrompt/editOrderItemPrompts.tsx
@@ -31,8 +31,13 @@ export default function EditOrderItemPrompt({
         quantity,
       };
       await onSave(editedItem);
-    } catch (e) {
-      setErrorText("Something went wrong. Couldn' edit the post.");
+    } catch (e: any) {
+      if (
+        e.response.data ==
+        "Medical Need Remaining Amount Exceeds Aid Package Item Amount"
+      )
+        setErrorText(e.response.data);
+      else setErrorText("Something went wrong. Couldn't edit the post.");
     }
     setIsSaving(false);
   };
@@ -41,6 +46,15 @@ export default function EditOrderItemPrompt({
     <div className="editOrderItemPrompt">
       <h4>Edit Order Item</h4>
       <div className="input">
+        <label htmlFor="orderItemQty">Initial Quantity</label>
+        <div>
+          <input
+            id="orderItemInitialQty"
+            value={orderItem.initialQuantity}
+            type="number"
+            readOnly
+          />
+        </div>
         <label htmlFor="orderItemQty">Quantity</label>
         <div>
           <input

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -6,12 +6,14 @@ interface PackageItemsTableProps {
   items: AidPackageItem[];
   onEditItemButtonClick: (item: AidPackageItem) => void;
   onDeleteButtonClick: (item: AidPackageItem) => void;
+  status: string;
 }
 
 export default function OrderItemsTable({
   items,
   onEditItemButtonClick,
   onDeleteButtonClick,
+  status,
 }: PackageItemsTableProps) {
   return (
     <table className="orderItemsTable">
@@ -19,7 +21,7 @@ export default function OrderItemsTable({
         <tr>
           <th>Item Name</th>
           <th>Quantity</th>
-          <th />
+          {status == "Draft" && <th />}
         </tr>
       </thead>
       <tbody>
@@ -27,15 +29,19 @@ export default function OrderItemsTable({
           <tr key={item.packageItemID}>
             <td>{item.quotation.brandName}</td>
             <td>{item.quantity}</td>
-            <td className="actions">
-              <button onClick={() => onEditItemButtonClick(item)}>Edit</button>
-              <button
-                className="deleteButton"
-                onClick={() => onDeleteButtonClick(item)}
-              >
-                delete
-              </button>
-            </td>
+            {status == "Draft" && (
+              <td className="actions">
+                <button onClick={() => onEditItemButtonClick(item)}>
+                  Edit
+                </button>
+                <button
+                  className="deleteButton"
+                  onClick={() => onDeleteButtonClick(item)}
+                >
+                  delete
+                </button>
+              </td>
+            )}
           </tr>
         ))}
       </tbody>

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -152,6 +152,7 @@ export function PackageDetails() {
               <p>{aidPackage.description}</p>
               <div>
                 <OrderItemsTable
+                  status={aidPackage?.status}
                   items={aidPackage?.aidPackageItems}
                   onEditItemButtonClick={handleEditOrderItemButtonClick}
                   onDeleteButtonClick={handlePackageItemDelete}

--- a/admin-portal/src/types/DonorAidPackageOrderItem.ts
+++ b/admin-portal/src/types/DonorAidPackageOrderItem.ts
@@ -7,6 +7,7 @@ export interface AidPackageItem {
   packageID: number;
   quotationID: number;
   quantity: number;
+  initialQuantity: number;
   totalAmount: number;
   needID: number;
   quotation: Quotation;


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #191 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Admins should be able see the initial quantities assigned when the aid package was created.

## Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![image](https://user-images.githubusercontent.com/72991092/179469703-66b59478-4fb0-4cac-8031-63ae3d8334b8.png)


