### PR TITLE
Allow forward status changes only

### DIFF
--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -23,7 +23,7 @@ export function PackageDetails() {
   const postToBeEdited = useRef<AidPackageUpdateComment | null>(null);
   const orderItemToBeEdited = useRef<AidPackageItem | null>(null);
 
-  const statusLevel = {
+  const statusToLevel = {
     Draft: 1,
     Published: 2,
     "Awaiting Payment": 3,
@@ -69,7 +69,7 @@ export function PackageDetails() {
       return;
     }
     if (aidPackage?.status) {
-      if (statusLevel[statusToBeChanged] < statusLevel[aidPackage.status]) {
+      if (statusToLevel[statusToBeChanged] < statusToLevel[aidPackage.status]) {
         alert("Sorry, you cannot change back to a previous status");
         return;
       }

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -23,6 +23,16 @@ export function PackageDetails() {
   const postToBeEdited = useRef<AidPackageUpdateComment | null>(null);
   const orderItemToBeEdited = useRef<AidPackageItem | null>(null);
 
+  const statusLevel = {
+    Draft: 1,
+    Published: 2,
+    "Awaiting Payment": 3,
+    Ordered: 4,
+    Shipped: 5,
+    "Received At MOH": 6,
+    Delivered: 7,
+  };
+
   useEffect(() => {
     fetchAidPackage();
     fetchUpdateComments();
@@ -57,6 +67,12 @@ export function PackageDetails() {
   const handleStatusChange = async (statusToBeChanged: AidPackage.Status) => {
     if (statusToBeChanged === aidPackage?.status) {
       return;
+    }
+    if (aidPackage?.status) {
+      if (statusLevel[statusToBeChanged] < statusLevel[aidPackage.status]) {
+        alert("Sorry, you cannot change back to a previous status");
+        return;
+      }
     }
     const confirmed = window.confirm(
       `Are you sure you want to change the status to ${statusToBeChanged}?`


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #194

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Currently admins can change aid package statuses to any status but they should be able to update it one-way(forward) only. 
