### PR TITLE
Allow creating multiple packages for different periods 

### DIFF
--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -3,6 +3,7 @@ import { AidPackage } from "../../types/AidPackage";
 import { AidPackageUpdateComment } from "../../types/AidPackageUpdateComment";
 import { AidPackageItem } from "../../types/DonorAidPackageOrderItem";
 import { Pledge } from "../../types/Pledge";
+import { Quotation } from "types/Quotation";
 
 export class AidPackageService {
   static http: Http;
@@ -88,6 +89,7 @@ export class AidPackageService {
     name: string;
     description: string;
     status: AidPackage.Status;
+    period: Quotation["period"];
     aidPackageItems: Array<{
       needID: number;
       quantity?: number;

--- a/admin-portal/src/helpers/aidPackageHelper.ts
+++ b/admin-portal/src/helpers/aidPackageHelper.ts
@@ -1,0 +1,20 @@
+import { Quotation } from "types/Quotation";
+
+export function getDraftAidPackageKey(quote: Quotation) {
+  return `${quote.supplierID}#${quote.period.year}-${quote.period.month}-${quote.period.day}`;
+}
+
+export function getSupplierIdFromAidPackageKey(aidPackageKey: string): number {
+  return Number(aidPackageKey.split("#")[0]);
+}
+
+export function getPeriodFromAidPackageKey(
+  aidPackageKey: string
+): Quotation["period"] {
+  const periodValues = aidPackageKey.split("#")[1].split("-").map(Number);
+  return {
+    year: periodValues[0],
+    month: periodValues[1],
+    day: periodValues[2],
+  };
+}

--- a/admin-portal/src/pages/aidPackage/assignSuppliers/assignSuppliers.tsx
+++ b/admin-portal/src/pages/aidPackage/assignSuppliers/assignSuppliers.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useTable, useExpanded, useGlobalFilter, CellValue } from "react-table";
-import { AidPackages, GlobalFilter, NeedAssignments } from "../aidPackage";
+import { DraftAidPackages, GlobalFilter, NeedAssignments } from "../aidPackage";
 import { SupplierNeedAllocationTable } from "./supplierNeedAllocationTable";
 import { MedicalNeed } from "../../../types/MedicalNeeds";
 import "./assignSuppliers.css";
@@ -15,7 +15,7 @@ export function AssignSuppliers({
   needAssignments: NeedAssignments;
   setNeedAssignments: (needAssignments: NeedAssignments) => void;
   medicalNeeds: MedicalNeed[];
-  aidPackages: AidPackages;
+  aidPackages: DraftAidPackages;
   setIsValidAssignment: (isValid: boolean) => void;
 }) {
   const getAssignedCount = (

--- a/admin-portal/src/pages/aidPackage/assignSuppliers/supplierNeedAllocationTable/index.tsx
+++ b/admin-portal/src/pages/aidPackage/assignSuppliers/supplierNeedAllocationTable/index.tsx
@@ -1,5 +1,6 @@
+import { getDraftAidPackageKey } from "helpers/aidPackageHelper";
 import { formatMoney } from "helpers/formatter";
-import { AidPackages, NeedAssignment } from "pages/aidPackage/aidPackage";
+import { DraftAidPackages, NeedAssignment } from "pages/aidPackage/aidPackage";
 import { useMemo, useState, useEffect } from "react";
 import { useTable, CellValue } from "react-table";
 import { Quotation } from "../../../../types/Quotation";
@@ -15,7 +16,7 @@ export function SupplierNeedAllocationTable({
   setAssignmentForSupplier: any;
   requiredQuantity: number;
   assignmentsForSupplier: NeedAssignment;
-  aidPackages: AidPackages;
+  aidPackages: DraftAidPackages;
 }) {
   supplierQuotes = supplierQuotes || [];
 
@@ -32,7 +33,7 @@ export function SupplierNeedAllocationTable({
           quantity,
           max: Math.min(requiredQuantity, quote.availableQuantity),
           supplierID: quote.supplierID,
-          published: aidPackages?.[quote.supplierID]?.isPublished,
+          published: aidPackages?.[getDraftAidPackageKey(quote)]?.isPublished,
           unitPrice: formatMoney(quote.unitPrice),
           total: formatMoney((quantity || 0) * quote.unitPrice),
         };

--- a/admin-portal/src/pages/aidPackage/manageAidPackages/aidPackageDetailsTable/index.tsx
+++ b/admin-portal/src/pages/aidPackage/manageAidPackages/aidPackageDetailsTable/index.tsx
@@ -1,28 +1,43 @@
+import {
+  getDraftAidPackageKey,
+  getSupplierIdFromAidPackageKey,
+} from "helpers/aidPackageHelper";
 import { formatMoney, formatNumber } from "helpers/formatter";
 import { getNeedFromId, getSupplierQuoteForNeed } from "helpers/needsHelper";
 import { useMemo } from "react";
 import { useTable } from "react-table";
 import { MedicalNeed } from "types/MedicalNeeds";
-import { AidPackage, NeedAssignments } from "../../aidPackage";
+import { DraftAidPackage, NeedAssignments } from "../../aidPackage";
 
 export function AidPackageDetailsTable({
   selectedPackage,
-  supplierID,
+  selectedPackageKey,
   needAssignments,
   updateAidPackage,
   medicalNeeds,
 }: {
-  selectedPackage: { name: string; details: string };
-  supplierID: number;
+  selectedPackage: DraftAidPackage;
+  selectedPackageKey: string;
   needAssignments: NeedAssignments;
-  updateAidPackage: (updatedAidPackages: AidPackage) => void;
+  updateAidPackage: (updatedAidPackages: DraftAidPackage) => void;
   medicalNeeds: MedicalNeed[];
 }) {
+  const supplierID = getSupplierIdFromAidPackageKey(selectedPackageKey);
+
   const data = useMemo(
     () =>
       Object.keys(needAssignments)
         .filter((needID) => {
           return needAssignments[needID].has(supplierID);
+        })
+        .filter((needID) => {
+          const supplierQuote = getSupplierQuoteForNeed({
+            medicalNeeds,
+            needID: Number(needID),
+            supplierID,
+          });
+
+          return selectedPackageKey == getDraftAidPackageKey(supplierQuote!);
         })
         .map((needID) => {
           const need = getNeedFromId(medicalNeeds, Number(needID));
@@ -42,7 +57,7 @@ export function AidPackageDetailsTable({
             totalCost: formatMoney(totalCost),
           };
         }),
-    [needAssignments, medicalNeeds, supplierID]
+    [needAssignments, medicalNeeds, selectedPackageKey, supplierID]
   );
 
   const columns = useMemo(

--- a/admin-portal/src/pages/aidPackage/manageAidPackages/aidPackagesTable/index.tsx
+++ b/admin-portal/src/pages/aidPackage/manageAidPackages/aidPackagesTable/index.tsx
@@ -1,10 +1,14 @@
+import {
+  getDraftAidPackageKey,
+  getSupplierIdFromAidPackageKey,
+} from "helpers/aidPackageHelper";
 import { formatDate, formatMoney } from "helpers/formatter";
 import { getSupplierQuoteForNeed } from "helpers/needsHelper";
 import { useCallback, useMemo, useState } from "react";
 import { useTable, useRowSelect } from "react-table";
 import { AidPackage } from "types/AidPackage";
 import { MedicalNeed } from "types/MedicalNeeds";
-import { AidPackages, NeedAssignments } from "../../aidPackage";
+import { DraftAidPackages, NeedAssignments } from "../../aidPackage";
 
 export function AidPackageTable({
   aidPackages,
@@ -13,10 +17,11 @@ export function AidPackageTable({
   medicalNeeds,
   needAssignments,
 }: {
-  aidPackages: AidPackages;
-  setSelectedPackage: (supplierID: number | null) => void;
+  aidPackages: DraftAidPackages;
+  setSelectedPackage: (key: string | null) => void;
   handleAidPkgPublish: (
     supplierId: number,
+    packageKey: string,
     status: AidPackage.Status
   ) => Promise<void>;
   medicalNeeds: MedicalNeed[];
@@ -26,22 +31,31 @@ export function AidPackageTable({
     () =>
       Object.keys(aidPackages)
         .filter((key) => {
-          let supplierID = Number(key);
-          return !aidPackages[supplierID].isPublished;
+          return !aidPackages[key].isPublished;
         })
         .map((key) => {
-          let supplierID = Number(key);
+          let supplierID = getSupplierIdFromAidPackageKey(key);
           let supplier: string = "";
           let period: Date = new Date();
 
           const needsWithSupplier = Object.keys(needAssignments)
-            .filter((needKey) => {
-              const assignments = needAssignments[needKey];
+            .filter((needID) => {
+              const assignments = needAssignments[Number(needID)];
               return assignments.has(supplierID);
+            })
+            .filter((needID) => {
+              const supplierQuote = getSupplierQuoteForNeed({
+                medicalNeeds,
+                needID: Number(needID),
+                supplierID,
+              });
+
+              return key == getDraftAidPackageKey(supplierQuote!);
             })
             .map(Number);
 
           const totalCost = needsWithSupplier.reduce((currentTotal, needID) => {
+            needID = Number(needID);
             const quote = getSupplierQuoteForNeed({
               medicalNeeds,
               needID,
@@ -64,13 +78,14 @@ export function AidPackageTable({
           }, 0);
 
           return {
-            name: aidPackages[supplierID].name,
+            key,
+            name: aidPackages[key].name,
             supplierID,
             supplier,
-            description: aidPackages[supplierID].details,
+            description: aidPackages[key].details,
             period: period ? formatDate(period) : "",
             totalCost: formatMoney(totalCost),
-            isPublished: aidPackages[supplierID].isPublished,
+            isPublished: aidPackages[key].isPublished,
           };
         }),
     [aidPackages, needAssignments, medicalNeeds]
@@ -83,11 +98,12 @@ export function AidPackageTable({
   const handlePublish = useCallback(
     (
       supplierId: number,
+      packageKey: string,
       status: AidPackage.Status,
       setIsUploading: (uploading: boolean) => void
     ) => {
       setIsUploading(true);
-      handleAidPkgPublish(supplierId, status)
+      handleAidPkgPublish(supplierId, packageKey, status)
         .then(() => {
           setSelectedPackage(null);
         })
@@ -131,6 +147,7 @@ export function AidPackageTable({
                 handlePublish={handlePublish}
                 label="Publish"
                 supplierID={row.original.supplierID}
+                packageKey={row.original.key}
                 setIsUploading={setIsUploading}
               />
               <PublishAidPackageButton
@@ -138,6 +155,7 @@ export function AidPackageTable({
                 handlePublish={handlePublish}
                 label="Save Draft"
                 supplierID={row.original.supplierID}
+                packageKey={row.original.key}
                 setIsUploading={setIsUploading}
               />
             </>
@@ -188,7 +206,7 @@ export function AidPackageTable({
             <tr
               {...row.getRowProps()}
               onClick={() => {
-                setSelectedPackage(row.original.supplierID);
+                setSelectedPackage(row.original.key);
                 toggleAllRowsSelected(false);
                 // @ts-ignore
                 row.toggleRowSelected(true);
@@ -215,12 +233,14 @@ function PublishAidPackageButton({
   status,
   label,
   setIsUploading,
+  packageKey,
 }: {
   handlePublish: Function;
   supplierID: number;
   status: AidPackage.Status;
   label: string;
   setIsUploading: Function;
+  packageKey: string;
 }) {
   return (
     <button
@@ -229,7 +249,7 @@ function PublishAidPackageButton({
       }`}
       onClick={(event) => {
         event.stopPropagation();
-        handlePublish(supplierID, status, setIsUploading);
+        handlePublish(supplierID, packageKey, status, setIsUploading);
       }}
     >
       {label}


### PR DESCRIPTION
Fixes #221 

- Allow saving packages for the same supplier but for different time periods.
- We pass the period the same way it's passed to us to the backend. 


Future work
- Refactor the create aid package flow to be more readable

