### PR TITLE
191 add comment when publishing package

### DIFF
--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -95,11 +95,33 @@ export class AidPackageService {
     }>;
   }) {
     // TODO:  Define interfaces for the data types.
-    return AidPackageService.http.post<any, any>(`aidpackages`, {
+    return AidPackageService.http.post<any, AidPackage>(`aidpackages`, {
       name,
       description,
       aidPackageItems,
       status,
     });
   }
+
+  static commentPublishedAidPackage(aidPackage: AidPackage) {
+    const comment =
+      "Aid package published with the following items:\n" +
+      aidPackage.aidPackageItems.map(getAidPackageItemComment).join("\n");
+
+    AidPackageService.upsertUpdateComment(aidPackage.packageID, {
+      packageUpdateID: 0,
+      packageID: aidPackage.packageID,
+      updateComment: comment,
+      dateTime: "",
+    });
+  }
+}
+
+function getAidPackageItemComment(item: AidPackageItem, index: number) {
+  index = index + 1;
+  const name = item.quotation.brandName;
+  const count = item.quantity;
+  const cost = item.totalAmount;
+
+  return `${index}. ${name} - Count: ${count} - Cost: $${cost}`;
 }

--- a/admin-portal/src/pages/aidPackage/aidPackage.tsx
+++ b/admin-portal/src/pages/aidPackage/aidPackage.tsx
@@ -100,7 +100,7 @@ export function CreateAidPackage() {
           };
         }),
       })
-        .then(() => {
+        .then(({ data }) => {
           toast(`Successfully Published ${aidPackage.name}`);
           /**
            * flags the package to be removed from
@@ -108,6 +108,7 @@ export function CreateAidPackage() {
            */
           aidPackages[supplierID].isPublished = true;
           setAidPackages({ ...aidPackages });
+          AidPackageService.commentPublishedAidPackage(data);
         })
         .catch((error) => {
           toast("something went wrong");

--- a/admin-portal/src/pages/packageDetails/components/updateComments/updatecomments.css
+++ b/admin-portal/src/pages/packageDetails/components/updateComments/updatecomments.css
@@ -36,6 +36,7 @@
 
 .updateComments .comment .content .text {
   flex-grow: 1;
+  white-space: pre-line;
 }
 
 .updateComments .comment .content .actions button {

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -88,6 +88,9 @@ export function PackageDetails() {
         status: statusToBeChanged,
       });
       setAidPackage(data);
+      if (statusToBeChanged === AidPackage.Status.Published) {
+        AidPackageService.commentPublishedAidPackage(data);
+      }
     }
   };
 


### PR DESCRIPTION
## Purpose
Fixes #191

## Goals
We allow packages to be changed after it has been published. 
But we would like to keep a log of the amount of the initial package.

To enable this, we are creating comments with the medicine name, amount, and cost that were there when published.

## Approach
The approach here is to post a comment from the front end at two places:

1. When the user publishes a new aid package from the aid package creation page
2. User publishes a draft aid package and then moves it into the published state.

---

This should be good enough to unblock the issue, but I think this would be best handled some other way.
Preferably by keeping the initial publish data in the DB.

### Screenshots
![image](https://user-images.githubusercontent.com/5859290/180486723-1435fc2c-698e-4bd9-aa87-3fe372834725.png)