### PR TITLE
limit the width of the progress bar to 100% even if the current amount is higher

### DIFF
--- a/donor-portal/src/components/progress-bar/index.tsx
+++ b/donor-portal/src/components/progress-bar/index.tsx
@@ -24,7 +24,13 @@ export default function SimpleProgressBar({
   useEffect(() => {
     if (containerRef.current) {
       const totalWidth = containerRef.current.clientWidth;
-      setInnerWidth((totalWidth / max) * current);
+
+      if (current > max) {
+        // this is a temporary fix, until the backend limits going beyond 100%
+        setInnerWidth(totalWidth);
+      } else {
+        setInnerWidth((totalWidth / max) * current);
+      }
     }
   }, [max, current, className, containerRef.current]);
 


### PR DESCRIPTION
## Purpose
#255 is temporarily taken care of from the Frontend, for now.
Pls don't close the issue since backend validations are required to be added to ensure that the amounts aren't exceeded.

## Approach
If the current value is greater than the max value, the progress bar width is set to the maximum possible width (100%)

### Screenshots
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/47103883/181514599-bec1837d-27fe-49f2-b4e8-d9b7b57a5929.png">
