### PR TITLE
Updated only the aid package status when changing the status from UI

### DIFF
--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -18,6 +18,7 @@ import { FiEdit3 } from "react-icons/fi";
 export function PackageDetails() {
   const { packageId } = useParams<{ packageId: string }>();
   const [aidPackage, setAidPackage] = useState<AidPackage>();
+  const [aidPackageStatus, setAidPackageStatus] = useState<AidPackage.Status>();
   const [posts, setPosts] = useState<AidPackageUpdateComment[]>([]);
   const [isEditPostModalVisible, setIsEditPostModalVisible] = useState(false);
   const [isEditOrderItemModalVisible, setIsEditOrderItemModalVisible] =
@@ -46,6 +47,7 @@ export function PackageDetails() {
   const fetchAidPackage = async () => {
     const { data } = await AidPackageService.getAidPackage(packageId!);
     setAidPackage(data);
+    setAidPackageStatus(data.status);
   };
 
   const fetchUpdateComments = async () => {
@@ -70,11 +72,11 @@ export function PackageDetails() {
   };
 
   const handleStatusChange = async (statusToBeChanged: AidPackage.Status) => {
-    if (statusToBeChanged === aidPackage?.status) {
+    if (statusToBeChanged === aidPackageStatus) {
       return;
     }
-    if (aidPackage?.status) {
-      if (statusToLevel[statusToBeChanged] < statusToLevel[aidPackage.status]) {
+    if (aidPackageStatus) {
+      if (statusToLevel[statusToBeChanged] < statusToLevel[aidPackageStatus]) {
         alert("Sorry, you cannot change back to a previous status");
         return;
       }
@@ -87,7 +89,7 @@ export function PackageDetails() {
         ...aidPackage!,
         status: statusToBeChanged,
       });
-      setAidPackage(data);
+      setAidPackageStatus(data.status);
       if (statusToBeChanged === AidPackage.Status.Published) {
         AidPackageService.commentPublishedAidPackage(data);
       }
@@ -160,7 +162,7 @@ export function PackageDetails() {
   return (
     <>
       {!aidPackage && <p>Loading Aid Package...</p>}
-      {aidPackage && (
+      {aidPackage && aidPackageStatus && (
         <div className="packageDetails">
           <Modal
             show={isEditOrderItemModalVisible}
@@ -241,7 +243,7 @@ export function PackageDetails() {
             </div>
           </div>
           <PackageStatus
-            currentStatus={aidPackage.status}
+            currentStatus={aidPackageStatus}
             onStatusChange={handleStatusChange}
           />
           <UpdateComments


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #290

Previously we have updated all aid package information even though we change only the status.
The PATCH API won't send all data. Because of that missing data above issue happens. 
So, I have updated only the aid package status when changing the status from UI. 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

Add additional states to keep aid package status. 

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->


https://user-images.githubusercontent.com/24244523/181575063-47bcce7e-4f35-4e97-8b5e-e046d32a65b3.mp4



## Related PRs
<!--- List any other related PRs --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
