### PR TITLE
Allow deleting and updating order items only on draft & published states

### DIFF
--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { AidPackage } from "../../../../types/AidPackage";
 import { AidPackageItem } from "../../../../types/DonorAidPackageOrderItem";
 import "./orderItemsTable.css";

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { AidPackage } from "../../../../types/AidPackage";
 import { AidPackageItem } from "../../../../types/DonorAidPackageOrderItem";
 import "./orderItemsTable.css";
@@ -16,6 +16,17 @@ export default function OrderItemsTable({
   onDeleteButtonClick,
   aidPackageStatus,
 }: PackageItemsTableProps) {
+  const [disableBtns, setDisableBtns] = useState<boolean>(false);
+
+  useEffect(() => {
+    setDisableBtns(
+      !(
+        aidPackageStatus === AidPackage.Status.Draft ||
+        aidPackageStatus === AidPackage.Status.Published
+      )
+    );
+  }, [aidPackageStatus]);
+
   return (
     <table className="orderItemsTable">
       <thead>
@@ -40,12 +51,7 @@ export default function OrderItemsTable({
               <button
                 type="button"
                 onClick={() => onEditItemButtonClick(item)}
-                disabled={
-                  !(
-                    aidPackageStatus === AidPackage.Status.Draft ||
-                    aidPackageStatus === AidPackage.Status.Published
-                  )
-                }
+                disabled={disableBtns}
               >
                 Edit
               </button>
@@ -53,12 +59,7 @@ export default function OrderItemsTable({
                 type="button"
                 className="deleteButton"
                 onClick={() => onDeleteButtonClick(item)}
-                disabled={
-                  !(
-                    aidPackageStatus === AidPackage.Status.Draft ||
-                    aidPackageStatus === AidPackage.Status.Published
-                  )
-                }
+                disabled={disableBtns}
               >
                 delete
               </button>

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -16,16 +16,10 @@ export default function OrderItemsTable({
   onDeleteButtonClick,
   aidPackageStatus,
 }: PackageItemsTableProps) {
-  const [disableBtns, setDisableBtns] = useState<boolean>(false);
-
-  useEffect(() => {
-    setDisableBtns(
-      !(
-        aidPackageStatus === AidPackage.Status.Draft ||
-        aidPackageStatus === AidPackage.Status.Published
-      )
-    );
-  }, [aidPackageStatus]);
+  const disableBtns = !(
+    aidPackageStatus === AidPackage.Status.Draft ||
+    aidPackageStatus === AidPackage.Status.Published
+  );
 
   return (
     <table className="orderItemsTable">

--- a/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
+++ b/admin-portal/src/pages/packageDetails/components/orderItemsTable/orderItemsTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AidPackage } from "../../../../types/AidPackage";
 import { AidPackageItem } from "../../../../types/DonorAidPackageOrderItem";
 import "./orderItemsTable.css";
 
@@ -6,12 +7,14 @@ interface PackageItemsTableProps {
   items: AidPackageItem[];
   onEditItemButtonClick: (item: AidPackageItem) => void;
   onDeleteButtonClick: (item: AidPackageItem) => void;
+  aidPackageStatus: AidPackage.Status;
 }
 
 export default function OrderItemsTable({
   items,
   onEditItemButtonClick,
   onDeleteButtonClick,
+  aidPackageStatus,
 }: PackageItemsTableProps) {
   return (
     <table className="orderItemsTable">
@@ -34,13 +37,28 @@ export default function OrderItemsTable({
               {item.period.day}/{item.period.month}/{item.period.year}
             </td>
             <td className="actions">
-              <button type="button" onClick={() => onEditItemButtonClick(item)}>
+              <button
+                type="button"
+                onClick={() => onEditItemButtonClick(item)}
+                disabled={
+                  !(
+                    aidPackageStatus === AidPackage.Status.Draft ||
+                    aidPackageStatus === AidPackage.Status.Published
+                  )
+                }
+              >
                 Edit
               </button>
               <button
                 type="button"
                 className="deleteButton"
                 onClick={() => onDeleteButtonClick(item)}
+                disabled={
+                  !(
+                    aidPackageStatus === AidPackage.Status.Draft ||
+                    aidPackageStatus === AidPackage.Status.Published
+                  )
+                }
               >
                 delete
               </button>

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -212,6 +212,7 @@ export default function PackageDetails() {
                   items={aidPackage?.aidPackageItems}
                   onEditItemButtonClick={handleEditOrderItemButtonClick}
                   onDeleteButtonClick={handlePackageItemDelete}
+                  aidPackageStatus={aidPackageStatus}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Purpose
FE validation of #303.
TODO: BE validation

## Goals
Disable edit/ delete items in an aid package once the package is in the 'Ordered' state.

## Approach
If the package status is not Draft or Published, the edit & delete buttons are disabled.