### PR TITLE
Fix received status not selecting issue

### DIFF
--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -35,7 +35,7 @@ export default function PackageDetails() {
     "Awaiting Payment": 3,
     Ordered: 4,
     Shipped: 5,
-    "Received At MOH": 6,
+    "Received at MoH": 6,
     Delivered: 7,
   };
 

--- a/admin-portal/src/types/AidPackage.ts
+++ b/admin-portal/src/types/AidPackage.ts
@@ -18,7 +18,7 @@ export namespace AidPackage {
     AwaitingPayment = "Awaiting Payment",
     Ordered = "Ordered",
     Shipped = "Shipped",
-    ReceivedAtMOH = "Received At MOH",
+    ReceivedAtMOH = "Received at MoH",
     Delivered = "Delivered",
   }
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #209

Fix `Received at MOH` status not selecting issue, when initial rendering.

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->


## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

GET AidPacakge API's status is not matched with the FE enum type. Updating the FE enum type to match the API status fixed the issue.


### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->

https://user-images.githubusercontent.com/24244523/182220832-fc512992-ac14-4184-a34a-32f2affb5496.mp4




## Related PRs
<!--- List any other related PRs --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
