### PR TITLE
Fix order completion confirmation warning

### DIFF
--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -42,6 +42,13 @@ export default function PackageDetails() {
     Delivered: 7,
   };
 
+  const completedStatuses = [
+    AidPackage.Status.Ordered,
+    AidPackage.Status.Shipped,
+    AidPackage.Status.ReceivedAtMOH,
+    AidPackage.Status.Delivered,
+  ];
+
   const fetchAidPackage = async () => {
     const { data } = await AidPackageService.getAidPackage(packageId!);
     setAidPackage(data);
@@ -94,9 +101,8 @@ export default function PackageDetails() {
     if (confirmed) {
       if (
         aidPackageStatus &&
-        (statusToLevel[aidPackageStatus] === 1 ||
-          statusToLevel[aidPackageStatus] === 2) &&
-        statusToLevel[statusToBeChanged] > 3
+        !completedStatuses.includes(aidPackageStatus) &&
+        completedStatuses.includes(statusToBeChanged)
       ) {
         const orderCompletionConfirmation = window.confirm(
           "You are trying to move this package into a 'completion' status!"

--- a/admin-portal/src/pages/packageDetails/packageDetails.tsx
+++ b/admin-portal/src/pages/packageDetails/packageDetails.tsx
@@ -92,6 +92,19 @@ export default function PackageDetails() {
       `Are you sure you want to change the status to ${statusToBeChanged}?`
     );
     if (confirmed) {
+      if (
+        aidPackageStatus &&
+        (statusToLevel[aidPackageStatus] === 1 ||
+          statusToLevel[aidPackageStatus] === 2) &&
+        statusToLevel[statusToBeChanged] > 3
+      ) {
+        const orderCompletionConfirmation = window.confirm(
+          "You are trying to move this package into a 'completion' status!"
+        );
+
+        if (!orderCompletionConfirmation) return; // don't update the status
+      }
+
       const { data } = await AidPackageService.updateAidPackage({
         ...aidPackage!,
         status: statusToBeChanged,


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #307

## Goal
Display the confirmation only when changing to a completion state from draft or Published.