### PR TITLE
Increase inline image size limit

### DIFF
--- a/donor-portal/package.json
+++ b/donor-portal/package.json
@@ -24,7 +24,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
+    "start": "IMAGE_INLINE_SIZE_LIMIT=10000000 ESLINT_NO_DEV_ERRORS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #336

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- To temporarily fix the Image loading issue on the donor portal.
More context on issue #336 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
This is a hot fix to #336. It needs to revert back once the issue is resolved.
- Increase the inline image size limit to 10000000 bytes (~10MB). So that all images will be rendered as inline images
