### PR TITLE
478 remove period from the package id key

### DIFF
--- a/admin-portal/src/apis/services/AidPackageService.ts
+++ b/admin-portal/src/apis/services/AidPackageService.ts
@@ -1,4 +1,3 @@
-import { Quotation } from "../../types/Quotation";
 import Http from "../httpCommon";
 import { AidPackage } from "../../types/AidPackage";
 import {
@@ -107,7 +106,6 @@ export default class AidPackageService {
     description: string;
     donorId: string;
     status: AidPackage.Status;
-    period: Quotation["period"];
     aidPackageItems: Array<{
       needID: number;
       quantity?: number;

--- a/admin-portal/src/helpers/aidPackageHelper.ts
+++ b/admin-portal/src/helpers/aidPackageHelper.ts
@@ -1,7 +1,7 @@
 import { Quotation } from "../types/Quotation";
 
 export function getDraftAidPackageKey(quote: Quotation) {
-  return `${quote.supplierID}`;
+  return quote.supplierID;
 }
 
 export function getSupplierIdFromAidPackageKey(aidPackageKey: string): number {

--- a/admin-portal/src/helpers/aidPackageHelper.ts
+++ b/admin-portal/src/helpers/aidPackageHelper.ts
@@ -1,7 +1,7 @@
 import { Quotation } from "../types/Quotation";
 
 export function getDraftAidPackageKey(quote: Quotation) {
-  return quote.supplierID;
+  return `${quote.supplierID}`;
 }
 
 export function getSupplierIdFromAidPackageKey(aidPackageKey: string): number {

--- a/admin-portal/src/helpers/aidPackageHelper.ts
+++ b/admin-portal/src/helpers/aidPackageHelper.ts
@@ -1,20 +1,9 @@
 import { Quotation } from "../types/Quotation";
 
 export function getDraftAidPackageKey(quote: Quotation) {
-  return `${quote.supplierID}#${quote.period.year}-${quote.period.month}-${quote.period.day}`;
+  return `${quote.supplierID}`;
 }
 
 export function getSupplierIdFromAidPackageKey(aidPackageKey: string): number {
-  return Number(aidPackageKey.split("#")[0]);
-}
-
-export function getPeriodFromAidPackageKey(
-  aidPackageKey: string
-): Quotation["period"] {
-  const periodValues = aidPackageKey.split("#")[1].split("-").map(Number);
-  return {
-    year: periodValues[0],
-    month: periodValues[1],
-    day: periodValues[2],
-  };
+  return Number(aidPackageKey);
 }

--- a/admin-portal/src/pages/aidPackage/aidPackage.tsx
+++ b/admin-portal/src/pages/aidPackage/aidPackage.tsx
@@ -94,7 +94,6 @@ export default function CreateAidPackage() {
           description: aidPackage.details,
           donorId: donorId!,
           status,
-          period: aidPackage.period,
           aidPackageItems: needs.map((need) => {
             const medicalNeed = medicalNeeds.find(
               (currentNeed) => currentNeed.needID === need.id

--- a/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.tsx
+++ b/admin-portal/src/pages/aidPackage/manageAidPackages/manageAidPackages.tsx
@@ -6,7 +6,6 @@ import { MedicalNeed } from "../../../types/MedicalNeeds";
 import { getSupplierQuoteForNeed } from "../../../helpers/needsHelper";
 import {
   getDraftAidPackageKey,
-  getPeriodFromAidPackageKey,
   getSupplierIdFromAidPackageKey,
 } from "../../../helpers/aidPackageHelper";
 import {
@@ -56,7 +55,6 @@ export default function ManageAidPackages({
       const syncedAidPackages: DraftAidPackages = {};
 
       Array.from(draftAidPackageKeys).forEach((draftAidPackageKey) => {
-        const period = getPeriodFromAidPackageKey(draftAidPackageKey);
         const supplierID = getSupplierIdFromAidPackageKey(draftAidPackageKey);
 
         if (aidPackages[draftAidPackageKey]) {
@@ -66,7 +64,6 @@ export default function ManageAidPackages({
           syncedAidPackages[draftAidPackageKey] = {
             name: "",
             details: "",
-            period,
             supplierID,
           };
         }

--- a/admin-portal/src/types/AidPackage.ts
+++ b/admin-portal/src/types/AidPackage.ts
@@ -1,5 +1,4 @@
 import { AidPackageItem } from "./DonorAidPackageOrderItem";
-import { Quotation } from "./Quotation";
 
 export interface AidPackage {
   packageID: number;
@@ -32,7 +31,6 @@ export type NeedAssignments = {
 
 export type DraftAidPackage = {
   supplierID: number;
-  period: Quotation["period"];
   name: string;
   details: string;
   isPublished?: boolean;


### PR DESCRIPTION
## Purpose
Allow creating packages for the same suppliers with multiple periods.

## Approach
Remove period when creating a aid package key. This will allow users to create multiple packages with the same id

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
