### PR TITLE
Fix donate now page text overflow issue

### DIFF
--- a/donor-portal/src/pages/donate-now/index.tsx
+++ b/donor-portal/src/pages/donate-now/index.tsx
@@ -24,7 +24,6 @@ function PackageCard({
 }) {
   const { packageID, receivedAmount, description, goalAmount, name } =
     donorPackage;
-  const CHARACTER_LIMIT = 350;
 
   return (
     <div className="package-card" key={packageID}>
@@ -43,16 +42,7 @@ function PackageCard({
             {buttonText}
           </Link>
         </div>
-        <p className="card_details__description">
-          {description.length > CHARACTER_LIMIT ? (
-            <>
-              {description.substring(0, CHARACTER_LIMIT).concat("...")}
-              <Link to={`/package/${packageID}`}>read more</Link>
-            </>
-          ) : (
-            description
-          )}
-        </p>
+        <p className="card_details__description">{description}</p>
         <div className="card_details__package_progress">
           <p className="card_details__package_progress_text">
             $

--- a/donor-portal/src/pages/donate-now/styles.css
+++ b/donor-portal/src/pages/donate-now/styles.css
@@ -63,6 +63,20 @@
   margin: 0;
 }
 
+.package-card .card-details__heading__text {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.package-card .card_details__description {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .card_details__package_progress_text {
   font-size: 1.2rem;
   font-weight: bold;


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #492

Significant text content will overflow donate now cards in mobile view. 

This PR will limit the description to maximum of 3 lines and the title to only one line. 
And remove the `read more` button since donate button will redirect to the same page with all information.
This PR handle change using only CSS webkit

### Screenshots
![Screenshot from 2022-09-20 23-17-46](https://user-images.githubusercontent.com/24244523/191330296-a42ac9b0-fe67-4cea-a0fc-a0129d6c1fb7.png)

<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot from 2022-09-20 23-16-24](https://user-images.githubusercontent.com/24244523/191330281-b1ae6bfa-1327-4590-9913-1b7492e15c1d.png)
