### PR TITLE
Remove validation to prevent creating aid packages when any aid packa…

### DIFF
--- a/admin-portal/src/pages/aidPackage/assignSuppliers/assignSuppliers.tsx
+++ b/admin-portal/src/pages/aidPackage/assignSuppliers/assignSuppliers.tsx
@@ -90,11 +90,6 @@ export default function AssignSuppliers({
           need.period.day
         );
 
-        // all remaining quantities must be zero or positive
-        if (remainingQuantity < 0) {
-          isValidSupplierAssignments = false;
-        }
-
         // all assignments must be less than supplier max and more than 0
         const assignmentForNeed = needAssignments[need.needID!];
         need.supplierQuotes.forEach((quote) => {


### PR DESCRIPTION
Remove validation to prevent creating aid packages when any aid package has a negative value

## Purpose
Temporary fix for #514

## Goals
Allow an admin user to create an aid package even if there're negative remaining needs values in the list of needs.