### PR TITLE
Move getAidPackages API from admin portal to donor

### DIFF
--- a/donor-portal/src/App.tsx
+++ b/donor-portal/src/App.tsx
@@ -42,10 +42,6 @@ function App() {
       httpRequest,
       `${process.env.REACT_APP_DONOR_BACKEND_URL}`
     );
-    AidPackageService.adminHttp = new Http(
-      httpRequest,
-      `${process.env.REACT_APP_ADMIN_BACKEND_URL}`
-    );
   }, [state.isAuthenticated]);
 
   const { pathname } = useLocation();

--- a/donor-portal/src/apis/httpCommon.ts
+++ b/donor-portal/src/apis/httpCommon.ts
@@ -5,9 +5,6 @@ import axios, { AxiosResponse } from "axios";
  TODO: Remove these HTTP clients and use HTTP class for public APIs
   once https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/134 merged.
 */
-export const adminHttpClient = axios.create({
-  baseURL: `${process.env.REACT_APP_ADMIN_BACKEND_URL}`,
-});
 
 export const donorHttpClient = axios.create({
   baseURL: `${process.env.REACT_APP_DONOR_BACKEND_URL}`,

--- a/donor-portal/src/apis/services/AidPackageService.ts
+++ b/donor-portal/src/apis/services/AidPackageService.ts
@@ -1,4 +1,4 @@
-import Http, { adminHttpClient, donorHttpClient } from "../httpCommon";
+import Http, { donorHttpClient } from "../httpCommon";
 import { AidPackage } from "../../types/AidPackage";
 import { AidPackageUpdateComment } from "../../types/AidPackageUpdateComment";
 import { Pledge } from "../../types/Pledge";
@@ -6,14 +6,12 @@ import { Pledge } from "../../types/Pledge";
 export default class AidPackageService {
   static donorHttp: Http;
 
-  static adminHttp: Http;
-
   static getAidPackages() {
     return donorHttpClient.get<AidPackage[]>("aidpackages");
   }
 
   static getAidPackage(packageID: number | string) {
-    return adminHttpClient.get<AidPackage>(`aidpackages/${packageID}`);
+    return donorHttpClient.get<AidPackage>(`aidpackages/${packageID}`);
   }
 
   static getPledgedAidPackages(donorId: string) {

--- a/donor-portal/src/config.ts
+++ b/donor-portal/src/config.ts
@@ -14,10 +14,7 @@ const SDKConfig: AuthReactConfig | STSClientConfig = {
   },
   storage: Storage.WebWorker,
   stsTokenEndpoint: "https://sts.choreo.dev/oauth2/token",
-  resourceServerURLs: [
-    `${process.env.REACT_APP_ADMIN_BACKEND_URL}`,
-    `${process.env.REACT_APP_DONOR_BACKEND_URL}`,
-  ],
+  resourceServerURLs: [`${process.env.REACT_APP_DONOR_BACKEND_URL}`],
   disableTrySignInSilently: false,
 };
 


### PR DESCRIPTION
Move API endpoints that use to get aid packages from admin-portal/AidPackageService to donor-portal/AidPackageService.

Resolves #495 
